### PR TITLE
Ícono de la página principal

### DIFF
--- a/resources/views/components/base_layout.blade.php
+++ b/resources/views/components/base_layout.blade.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     @vite(["resources/css/app.css", "resources/js/app.js" ])
-    <link href="{{ asset('images/web.png') }}" rel="shortcut icon">
+    <link href="{{ asset('img/web.png') }}" rel="shortcut icon" type="image/png">
     <title>Incidencia</title>    
 </head>
 <body>


### PR DESCRIPTION
Se corrigió el ícono de la página principal, ya que no estaba bien ubicado.